### PR TITLE
Different approach to vmcatcher checks

### DIFF
--- a/lib/nagios/promoo.rb
+++ b/lib/nagios/promoo.rb
@@ -1,9 +1,11 @@
 # Global deps
+require 'active_support/all'
 require 'thor'
 require 'timeout'
 require 'ox'
 require 'multi_xml'
 require 'httparty'
+require 'date'
 
 # Force multi_xml to use ox
 MultiXml.parser = :ox

--- a/lib/nagios/promoo/appdb/version.rb
+++ b/lib/nagios/promoo/appdb/version.rb
@@ -1,7 +1,7 @@
 module Nagios
   module Promoo
     module Appdb
-      VERSION = "1.0.0"
+      VERSION = "1.1.0"
     end
   end
 end

--- a/lib/nagios/promoo/version.rb
+++ b/lib/nagios/promoo/version.rb
@@ -1,5 +1,5 @@
 module Nagios
   module Promoo
-    VERSION = "1.0.0"
+    VERSION = "1.1.0"
   end
 end


### PR DESCRIPTION
Using `--warning-after` and `--critical-after` to specify time (in hours, after an image list update) when the probe should start raising WARN/CRIT if it encounters outdated or missing appliances.